### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<logback-version>1.0.1</logback-version>
 		<commons-beanutils-version>1.8.3</commons-beanutils-version>
 		<commons-codec-version>1.4</commons-codec-version>
-		<commons-collections-version>3.2.1</commons-collections-version>
+		<commons-collections-version>3.2.2</commons-collections-version>
 		<commons-digester-version>2.0</commons-digester-version>
 		<commons-lang-version>2.4</commons-lang-version>
 


### PR DESCRIPTION

Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/